### PR TITLE
Change ssreflect import, as ssreflect is now included in Coq.

### DIFF
--- a/qc/Typeclasses.v
+++ b/qc/Typeclasses.v
@@ -890,7 +890,7 @@ Proof. intros. eapply trans3; eassumption. Defined.
 (** The [ssreflect] library defines what it means for a proposition
     [P] to be decidable like this... *)
 
-From mathcomp.ssreflect Require Import ssreflect ssrbool.
+Require Import ssreflect ssrbool.
 
 Print decidable.
 (* ==>


### PR DESCRIPTION
ssreflect is now in Coq by default, if people don't have an old mathcomp.ssreflect installed they can not get past this line.