### PR TITLE
Update README to include opam update.

### DIFF
--- a/verdi/lec1/StructTact/README.md
+++ b/verdi/lec1/StructTact/README.md
@@ -25,6 +25,7 @@ The easiest way to install StructTact is via [OPAM](http://opam.ocaml.org/doc/In
 
 ```
 opam repo add distributedcomponents-dev http://opam-dev.distributedcomponents.net
+opam update
 opam install StructTact
 ```
 


### PR DESCRIPTION
Without opam update, opam does not fetch the packages from the new repo, so it won't know about StructTact when you try to install it.